### PR TITLE
ci: fixes missing module for the docker-build workflow [skip ci]

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,7 +36,9 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKERHUB_REPO: ${{ github.event.inputs.repository }}
         run: |
-          mvn compile jib:build -pl ojp-server \
+            mvn install -N -DskipTests
+            mvn install -pl ojp-grpc-commons -DskipTests
+            mvn compile jib:build -pl ojp-server \
             -Djib.to.auth.username="${DOCKERHUB_USER}" \
             -Djib.to.auth.password="${DOCKERHUB_TOKEN}" \
             -Djib.to.image="${DOCKERHUB_REPO}/ojp:${{ github.event.inputs.tag }}" \


### PR DESCRIPTION
This is a fix for the Docker Build Workflow.
The problem was that the common module wasn't being compiled before the ojp-server so I added 3 new maven cmd

1. Install parent pom without child modules to make sure the pom is available in the local repository
2. Build the commons module
3. Build and publish ojp-server module Docker image